### PR TITLE
0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.7.0]
+### Updates
+- Added close method with streams cleanup
+- Added proper backpressure handling during write operations with queue management
+- Improved write performance
+- Added newline at the end of the last line to match POSIX requirements
+- Added more tests
+### Fixes
+- Fixed an issue when Compressed Dataset-JSON was written to existing file
+- Fixed an issue in readRecords for NDJSON folder, when it did not read beyond buffer length
+- In case of compressed format, the write method promise is now resolved then the file is finished writing
+
 ## [0.6.1]
 ### Updates
 - Add addCount parameter in the getUniqueValues method 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,21 @@ await dataset.writeData({
 });
 ```
 
+### `close`
+
+Closes all open streams and resets internal state. This method should be called when you're done working with a dataset to properly release resources.
+
+#### Returns
+
+- `Promise<void>`: A promise that resolves when all streams are closed and resources are released.
+
+#### Example
+
+```typescript
+// After finishing operations with the dataset
+await dataset.close();
+```
+
 ----
 
 ## Running Tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "js-stream-dataset-json",
-    "version": "0.6.1",
+    "version": "0.7.0",
     "description": "Stream Dataset-JSON files",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/test/write.test.ts
+++ b/test/write.test.ts
@@ -249,7 +249,7 @@ describe('DatasetJson write tests', () => {
                 data: largeTestData.concat([['STUDY01-SITE01-SUBJ01001', 35]])
             });
 
-            // // Verify the file contents
+            // Verify the file contents
             const compressedContent = fs.readFileSync(testCompressedPath);
             const decompressedContent = zlib.gunzipSync(compressedContent).toString();
             const lines = decompressedContent.trim().split('\n');


### PR DESCRIPTION
### Updates
- Added close method with streams cleanup
- Added proper backpressure handling during write operations with queue management
- Improved write performance
- Added newline at the end of the last line to match POSIX requirements
- Added more tests 
### Fixes
- Fixed an issue when Compressed Dataset-JSON was written to existing file
- Fixed an issue in readRecords for NDJSON folder, when it did not read beyond buffer length
- In case of compressed format, the write method promise is now resolved then the file is finished writing